### PR TITLE
Export attribute package

### DIFF
--- a/generatorapi/src/main/java/module-info.java
+++ b/generatorapi/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 module com.kneelwak.kfractal.generator.api {
     exports com.kneelawk.kfractal.generator.api;
     exports com.kneelawk.kfractal.generator.api.ir;
+    exports com.kneelawk.kfractal.generator.api.ir.attribute;
     exports com.kneelawk.kfractal.generator.api.ir.instruction;
     exports com.kneelawk.kfractal.generator.api.ir.instruction.io;
 


### PR DESCRIPTION
This allows the attribute system to be accessed from outside the 'generatorapi' module.