### PR TITLE
Add code engine interface

### DIFF
--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/FractalEngineException.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/FractalEngineException.java
@@ -1,0 +1,20 @@
+package com.kneelawk.kfractal.generator.api.engine;
+
+import com.kneelawk.kfractal.generator.api.FractalException;
+
+public class FractalEngineException extends FractalException {
+	public FractalEngineException() {
+	}
+
+	public FractalEngineException(String message) {
+		super(message);
+	}
+
+	public FractalEngineException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public FractalEngineException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/IProgramEngine.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/IProgramEngine.java
@@ -1,0 +1,26 @@
+package com.kneelawk.kfractal.generator.api.engine;
+
+import com.kneelawk.kfractal.generator.api.engine.value.IEngineValue;
+import com.kneelawk.kfractal.generator.api.engine.value.IEngineValueFactory;
+import com.kneelawk.kfractal.generator.api.engine.value.IFunctionValue;
+import com.kneelawk.kfractal.generator.api.ir.Program;
+import com.kneelawk.kfractal.generator.api.ir.ValueType;
+import com.kneelawk.kfractal.generator.api.ir.ValueTypes;
+
+import java.util.function.Supplier;
+
+public interface IProgramEngine {
+	void initialize(Program program);
+
+	IEngineValueFactory getValueFactory();
+
+	ValueType getGlobalValueType(String name);
+
+	IEngineValue getGlobalValue(String name);
+
+	void setGlobalValue(String name, IEngineValue value);
+
+	ValueTypes.FunctionType getFunctionSignature(String name);
+
+	IFunctionValue getFunction(String name, IEngineValue[] contextValues);
+}

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/IProgramEngine.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/IProgramEngine.java
@@ -10,17 +10,17 @@ import com.kneelawk.kfractal.generator.api.ir.ValueTypes;
 import java.util.function.Supplier;
 
 public interface IProgramEngine {
-	void initialize(Program program);
+	void initialize(Program program) throws FractalEngineException;
 
-	IEngineValueFactory getValueFactory();
+	IEngineValueFactory getValueFactory() throws FractalEngineException;
 
-	ValueType getGlobalValueType(String name);
+	ValueType getGlobalValueType(String name) throws FractalEngineException;
 
-	IEngineValue getGlobalValue(String name);
+	IEngineValue getGlobalValue(String name) throws FractalEngineException;
 
-	void setGlobalValue(String name, IEngineValue value);
+	void setGlobalValue(String name, IEngineValue value) throws FractalEngineException;
 
-	ValueTypes.FunctionType getFunctionSignature(String name);
+	ValueTypes.FunctionType getFunctionSignature(String name) throws FractalEngineException;
 
-	IFunctionValue getFunction(String name, IEngineValue[] contextValues);
+	IFunctionValue getFunction(String name, IEngineValue[] contextValues) throws FractalEngineException;
 }

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IBoolValue.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IBoolValue.java
@@ -1,0 +1,5 @@
+package com.kneelawk.kfractal.generator.api.engine.value;
+
+public interface IBoolValue extends IEngineValue {
+	boolean getValue();
+}

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IBoolValue.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IBoolValue.java
@@ -1,5 +1,7 @@
 package com.kneelawk.kfractal.generator.api.engine.value;
 
+import com.kneelawk.kfractal.generator.api.engine.FractalEngineException;
+
 public interface IBoolValue extends IEngineValue {
-	boolean getValue();
+	boolean getValue() throws FractalEngineException;
 }

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IComplexValue.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IComplexValue.java
@@ -1,0 +1,7 @@
+package com.kneelawk.kfractal.generator.api.engine.value;
+
+import org.apache.commons.math3.complex.Complex;
+
+public interface IComplexValue extends IEngineValue {
+	Complex getValue();
+}

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IComplexValue.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IComplexValue.java
@@ -1,7 +1,8 @@
 package com.kneelawk.kfractal.generator.api.engine.value;
 
+import com.kneelawk.kfractal.generator.api.engine.FractalEngineException;
 import org.apache.commons.math3.complex.Complex;
 
 public interface IComplexValue extends IEngineValue {
-	Complex getValue();
+	Complex getValue() throws FractalEngineException;
 }

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IEngineValue.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IEngineValue.java
@@ -1,0 +1,7 @@
+package com.kneelawk.kfractal.generator.api.engine.value;
+
+import com.kneelawk.kfractal.generator.api.ir.ValueType;
+
+public interface IEngineValue {
+	ValueType getType();
+}

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IEngineValue.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IEngineValue.java
@@ -1,7 +1,8 @@
 package com.kneelawk.kfractal.generator.api.engine.value;
 
+import com.kneelawk.kfractal.generator.api.engine.FractalEngineException;
 import com.kneelawk.kfractal.generator.api.ir.ValueType;
 
 public interface IEngineValue {
-	ValueType getType();
+	ValueType getType() throws FractalEngineException;
 }

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IEngineValueFactory.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IEngineValueFactory.java
@@ -1,0 +1,19 @@
+package com.kneelawk.kfractal.generator.api.engine.value;
+
+import org.apache.commons.math3.complex.Complex;
+
+public interface IEngineValueFactory {
+	IBoolValue newBool(boolean b);
+
+	IIntValue newInt(int i);
+
+	IRealValue newReal(double d);
+
+	IComplexValue newComplex(Complex complex);
+
+	IFunctionValue newFunction(String name, IEngineValue[] contextValues);
+
+	IPointerValue newPointer(IEngineValue referencedData);
+
+	IPointerValue nullPointer();
+}

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IEngineValueFactory.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IEngineValueFactory.java
@@ -1,19 +1,20 @@
 package com.kneelawk.kfractal.generator.api.engine.value;
 
+import com.kneelawk.kfractal.generator.api.engine.FractalEngineException;
 import org.apache.commons.math3.complex.Complex;
 
 public interface IEngineValueFactory {
-	IBoolValue newBool(boolean b);
+	IBoolValue newBool(boolean b) throws FractalEngineException;
 
-	IIntValue newInt(int i);
+	IIntValue newInt(int i) throws FractalEngineException;
 
-	IRealValue newReal(double d);
+	IRealValue newReal(double d) throws FractalEngineException;
 
-	IComplexValue newComplex(Complex complex);
+	IComplexValue newComplex(Complex complex) throws FractalEngineException;
 
-	IFunctionValue newFunction(String name, IEngineValue[] contextValues);
+	IFunctionValue newFunction(String name, IEngineValue[] contextValues) throws FractalEngineException;
 
-	IPointerValue newPointer(IEngineValue referencedData);
+	IPointerValue newPointer(IEngineValue referencedData) throws FractalEngineException;
 
-	IPointerValue nullPointer();
+	IPointerValue nullPointer() throws FractalEngineException;
 }

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IFunctionValue.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IFunctionValue.java
@@ -1,0 +1,9 @@
+package com.kneelawk.kfractal.generator.api.engine.value;
+
+import com.kneelawk.kfractal.generator.api.ir.ValueTypes;
+
+public interface IFunctionValue extends IEngineValue {
+	ValueTypes.FunctionType getSignature();
+
+	IEngineValue invoke(IEngineValue[] arguments);
+}

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IFunctionValue.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IFunctionValue.java
@@ -1,9 +1,10 @@
 package com.kneelawk.kfractal.generator.api.engine.value;
 
+import com.kneelawk.kfractal.generator.api.engine.FractalEngineException;
 import com.kneelawk.kfractal.generator.api.ir.ValueTypes;
 
 public interface IFunctionValue extends IEngineValue {
-	ValueTypes.FunctionType getSignature();
+	ValueTypes.FunctionType getSignature() throws FractalEngineException;
 
-	IEngineValue invoke(IEngineValue[] arguments);
+	IEngineValue invoke(IEngineValue[] arguments) throws FractalEngineException;
 }

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IIntValue.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IIntValue.java
@@ -1,5 +1,7 @@
 package com.kneelawk.kfractal.generator.api.engine.value;
 
+import com.kneelawk.kfractal.generator.api.engine.FractalEngineException;
+
 public interface IIntValue extends IEngineValue {
-	int getValue();
+	int getValue() throws FractalEngineException;
 }

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IIntValue.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IIntValue.java
@@ -1,0 +1,5 @@
+package com.kneelawk.kfractal.generator.api.engine.value;
+
+public interface IIntValue extends IEngineValue {
+	int getValue();
+}

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IPointerValue.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IPointerValue.java
@@ -1,0 +1,11 @@
+package com.kneelawk.kfractal.generator.api.engine.value;
+
+import com.kneelawk.kfractal.generator.api.ir.ValueType;
+
+public interface IPointerValue extends IEngineValue {
+	ValueType getDataType();
+
+	IEngineValue getReferencedData();
+
+	void setReferencedData(IEngineValue data);
+}

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IPointerValue.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IPointerValue.java
@@ -1,11 +1,12 @@
 package com.kneelawk.kfractal.generator.api.engine.value;
 
+import com.kneelawk.kfractal.generator.api.engine.FractalEngineException;
 import com.kneelawk.kfractal.generator.api.ir.ValueType;
 
 public interface IPointerValue extends IEngineValue {
-	ValueType getDataType();
+	ValueType getDataType() throws FractalEngineException;
 
-	IEngineValue getReferencedData();
+	IEngineValue getReferencedData() throws FractalEngineException;
 
-	void setReferencedData(IEngineValue data);
+	void setReferencedData(IEngineValue data) throws FractalEngineException;
 }

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IRealValue.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IRealValue.java
@@ -1,0 +1,5 @@
+package com.kneelawk.kfractal.generator.api.engine.value;
+
+public interface IRealValue extends IEngineValue {
+	double getValue();
+}

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IRealValue.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IRealValue.java
@@ -1,5 +1,7 @@
 package com.kneelawk.kfractal.generator.api.engine.value;
 
+import com.kneelawk.kfractal.generator.api.engine.FractalEngineException;
+
 public interface IRealValue extends IEngineValue {
-	double getValue();
+	double getValue() throws FractalEngineException;
 }


### PR DESCRIPTION
This is an interface for more general purpose use of the Fractal IR language system. This will allow generalized unit tests that can be run on multiple code engines.