### PR TITLE
Fix various generator api issues

### DIFF
--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/IProgramEngine.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/IProgramEngine.java
@@ -7,8 +7,6 @@ import com.kneelawk.kfractal.generator.api.ir.Program;
 import com.kneelawk.kfractal.generator.api.ir.ValueType;
 import com.kneelawk.kfractal.generator.api.ir.ValueTypes;
 
-import java.util.function.Supplier;
-
 public interface IProgramEngine {
 	void initialize(Program program) throws FractalEngineException;
 

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/ir/instruction/ComplexPower.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/ir/instruction/ComplexPower.java
@@ -17,9 +17,9 @@ public class ComplexPower implements IInstruction {
 	private IInstructionInput base;
 	private IInstructionInput exponent;
 
-	public ComplexPower(IInstructionOutput result,
-						IInstructionInput base,
-						IInstructionInput exponent) {
+	private ComplexPower(IInstructionOutput result,
+						 IInstructionInput base,
+						 IInstructionInput exponent) {
 		this.result = result;
 		this.base = base;
 		this.exponent = exponent;

--- a/generatorapi/src/main/java/module-info.java
+++ b/generatorapi/src/main/java/module-info.java
@@ -1,5 +1,7 @@
 module com.kneelwak.kfractal.generator.api {
     exports com.kneelawk.kfractal.generator.api;
+    exports com.kneelawk.kfractal.generator.api.engine;
+    exports com.kneelawk.kfractal.generator.api.engine.value;
     exports com.kneelawk.kfractal.generator.api.ir;
     exports com.kneelawk.kfractal.generator.api.ir.attribute;
     exports com.kneelawk.kfractal.generator.api.ir.instruction;

--- a/generatorapi/src/main/java/module-info.java
+++ b/generatorapi/src/main/java/module-info.java
@@ -1,4 +1,4 @@
-module com.kneelwak.kfractal.generator.api {
+module com.kneelawk.kfractal.generator.api {
     exports com.kneelawk.kfractal.generator.api;
     exports com.kneelawk.kfractal.generator.api.engine;
     exports com.kneelawk.kfractal.generator.api.engine.value;


### PR DESCRIPTION
The issues fixed mainly consist of little things like typos and forgetting to limit/grant access to certain parts of the api.

One of the more major changes was changing the ValueType system so that FuntionTypes and PointerTypes now rely entirely on their instance caching system for equals and hashcode functionality. This removes duplicate functionality left over from before the instance cashing system. This also allows NULL_FUNCTIONs and NULL_POINTERs to be more streamlined in their identification systems.