### PR TITLE
Make lists of arguments supplied to IProgramEngines and associated pa…

### DIFF
--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/IProgramEngine.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/IProgramEngine.java
@@ -7,6 +7,8 @@ import com.kneelawk.kfractal.generator.api.ir.Program;
 import com.kneelawk.kfractal.generator.api.ir.ValueType;
 import com.kneelawk.kfractal.generator.api.ir.ValueTypes;
 
+import java.util.List;
+
 public interface IProgramEngine {
     void initialize(Program program) throws FractalEngineException;
 
@@ -20,5 +22,5 @@ public interface IProgramEngine {
 
     ValueTypes.FunctionType getFunctionSignature(String name) throws FractalEngineException;
 
-    IFunctionValue getFunction(String name, IEngineValue[] contextValues) throws FractalEngineException;
+    IFunctionValue getFunction(String name, List<IEngineValue> contextValues) throws FractalEngineException;
 }

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IEngineValueFactory.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IEngineValueFactory.java
@@ -3,6 +3,8 @@ package com.kneelawk.kfractal.generator.api.engine.value;
 import com.kneelawk.kfractal.generator.api.engine.FractalEngineException;
 import org.apache.commons.math3.complex.Complex;
 
+import java.util.List;
+
 public interface IEngineValueFactory {
     IBoolValue newBool(boolean b) throws FractalEngineException;
 
@@ -12,7 +14,7 @@ public interface IEngineValueFactory {
 
     IComplexValue newComplex(Complex complex) throws FractalEngineException;
 
-    IFunctionValue newFunction(String name, IEngineValue[] contextValues) throws FractalEngineException;
+    IFunctionValue newFunction(String name, List<IEngineValue> contextValues) throws FractalEngineException;
 
     IFunctionValue nullFunction() throws FractalEngineException;
 

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IFunctionValue.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/engine/value/IFunctionValue.java
@@ -3,8 +3,10 @@ package com.kneelawk.kfractal.generator.api.engine.value;
 import com.kneelawk.kfractal.generator.api.engine.FractalEngineException;
 import com.kneelawk.kfractal.generator.api.ir.ValueTypes;
 
+import java.util.List;
+
 public interface IFunctionValue extends IEngineValue {
     ValueTypes.FunctionType getSignature() throws FractalEngineException;
 
-    IEngineValue invoke(IEngineValue[] arguments) throws FractalEngineException;
+    IEngineValue invoke(List<IEngineValue> arguments) throws FractalEngineException;
 }


### PR DESCRIPTION
This makes lists of arguments supplied to IProgramEngines and associated parts be java.util.Lists instead of simple java arrays.
This should fix #22.