### PR TITLE
String global names

### DIFF
--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/ir/Program.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/ir/Program.java
@@ -1,14 +1,15 @@
 package com.kneelawk.kfractal.generator.api.ir;
 
 import com.google.common.base.Suppliers;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.kneelawk.kfractal.util.KFractalToStringStyle;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -16,20 +17,20 @@ import java.util.stream.Collectors;
  * Created by Kneelawk on 5/25/19.
  */
 public class Program {
-    private List<GlobalDeclaration> globalVariables;
-    private List<FunctionDefinition> functions;
+    private Map<String, GlobalDeclaration> globalVariables;
+    private Map<String, FunctionDefinition> functions;
 
-    private Program(List<GlobalDeclaration> globalVariables,
-                    List<FunctionDefinition> functions) {
+    private Program(Map<String, GlobalDeclaration> globalVariables,
+                    Map<String, FunctionDefinition> functions) {
         this.globalVariables = globalVariables;
         this.functions = functions;
     }
 
-    public List<GlobalDeclaration> getGlobalVariables() {
+    public Map<String, GlobalDeclaration> getGlobalVariables() {
         return globalVariables;
     }
 
-    public List<FunctionDefinition> getFunctions() {
+    public Map<String, FunctionDefinition> getFunctions() {
         return functions;
     }
 
@@ -42,131 +43,141 @@ public class Program {
     }
 
     public static Program create(
-            List<GlobalDeclaration> globalVariables,
-            List<FunctionDefinition> functions) {
-        return new Program(ImmutableList.copyOf(globalVariables), ImmutableList.copyOf(functions));
+            Map<String, GlobalDeclaration> globalVariables,
+            Map<String, FunctionDefinition> functions) {
+        return new Program(ImmutableMap.copyOf(globalVariables), ImmutableMap.copyOf(functions));
     }
 
     public static class Builder {
-        private List<Supplier<GlobalDeclaration>> globalVariables = Lists.newArrayList();
-        private List<Supplier<FunctionDefinition>> functions = Lists.newArrayList();
+        private Map<String, Supplier<GlobalDeclaration>> globalVariables = Maps.newHashMap();
+        private Map<String, Supplier<FunctionDefinition>> functions = Maps.newHashMap();
 
         public Builder() {
         }
 
-        public Builder(Collection<Supplier<GlobalDeclaration>> globalVariables,
-                       Collection<Supplier<FunctionDefinition>> functions) {
-            this.globalVariables.addAll(globalVariables);
-            this.functions.addAll(functions);
+        public Builder(Map<String, Supplier<GlobalDeclaration>> globalVariables,
+                       Map<String, Supplier<FunctionDefinition>> functions) {
+            this.globalVariables.putAll(globalVariables);
+            this.functions.putAll(functions);
         }
 
         public Program build() {
-            return new Program(globalVariables.stream().map(Supplier::get).collect(ImmutableList.toImmutableList()),
-                    functions.stream().map(Supplier::get).collect(ImmutableList.toImmutableList()));
+            return new Program(
+                    globalVariables.entrySet().stream().map(e -> Pair.of(e.getKey(), e.getValue().get()))
+                            .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue)),
+                    functions.entrySet().stream().map(e -> Pair.of(e.getKey(), e.getValue().get()))
+                            .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue)));
         }
 
-        public List<Supplier<GlobalDeclaration>> getGlobalVariables() {
+        public Map<String, Supplier<GlobalDeclaration>> getGlobalVariables() {
             return globalVariables;
         }
 
-        public int getNextGlobalVariableIndex() {
-            return globalVariables.size();
-        }
-
         public Builder setGlobalVariableSuppliers(
-                Collection<Supplier<GlobalDeclaration>> globalVariables) {
+                Collection<Map.Entry<String, Supplier<GlobalDeclaration>>> globalVariables) {
             this.globalVariables.clear();
-            this.globalVariables.addAll(globalVariables);
+            this.globalVariables.putAll(ImmutableMap.copyOf(globalVariables));
             return this;
         }
 
-        public Builder setGlobalVariables(Collection<GlobalDeclaration> globalVariables) {
+        public Builder setGlobalVariables(Collection<Map.Entry<String, GlobalDeclaration>> globalVariables) {
             this.globalVariables.clear();
-            this.globalVariables
-                    .addAll(globalVariables.stream().map(Suppliers::ofInstance).collect(Collectors.toList()));
+            this.globalVariables.putAll(globalVariables.stream()
+                    .map(e -> Pair.of(e.getKey(), Suppliers.ofInstance(e.getValue())))
+                    .collect(Collectors.toMap(Pair::getKey, Pair::getValue)));
             return this;
         }
 
-        public int addGlobalVariable(Supplier<GlobalDeclaration> declaration) {
-            globalVariables.add(declaration);
-            return globalVariables.size() - 1;
+        public Builder addGlobalVariable(String name, Supplier<GlobalDeclaration> declaration) {
+            globalVariables.put(name, declaration);
+            return this;
         }
 
-        public int addGlobalVariable(GlobalDeclaration declaration) {
-            globalVariables.add(Suppliers.ofInstance(declaration));
-            return globalVariables.size() - 1;
+        public Builder addGlobalVariable(String name, GlobalDeclaration declaration) {
+            globalVariables.put(name, Suppliers.ofInstance(declaration));
+            return this;
         }
 
         @SafeVarargs
-        public final Builder addGlobalVariables(Supplier<GlobalDeclaration>... declarations) {
-            globalVariables.addAll(Arrays.asList(declarations));
+        public final Builder addGlobalVariableSuppliers(
+                Map.Entry<String, Supplier<GlobalDeclaration>>... declarations) {
+            globalVariables.putAll(Arrays.stream(declarations)
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
             return this;
         }
 
-        public final Builder addGlobalVariables(GlobalDeclaration... declarations) {
-            globalVariables.addAll(Arrays.stream(declarations).map(Suppliers::ofInstance).collect(Collectors.toList()));
+        @SafeVarargs
+        public final Builder addGlobalVariables(Map.Entry<String, GlobalDeclaration>... declarations) {
+            globalVariables.putAll(Arrays.stream(declarations)
+                    .map(p -> Pair.of(p.getKey(), Suppliers.ofInstance(p.getValue())))
+                    .collect(Collectors.toMap(Pair::getKey, Pair::getValue)));
             return this;
         }
 
-        public Builder addGlobalVariableSuppliers(Collection<Supplier<GlobalDeclaration>> declarations) {
-            globalVariables.addAll(declarations);
+        public Builder addGlobalVariableSuppliers(
+                Collection<Map.Entry<String, Supplier<GlobalDeclaration>>> declarations) {
+            globalVariables.putAll(ImmutableMap.copyOf(declarations));
             return this;
         }
 
-        public Builder addGlobalVariables(Collection<GlobalDeclaration> declarations) {
-            globalVariables.addAll(declarations.stream().map(Suppliers::ofInstance).collect(Collectors.toList()));
+        public Builder addGlobalVariables(Collection<Map.Entry<String, GlobalDeclaration>> declarations) {
+            globalVariables
+                    .putAll(declarations.stream().map(e -> Pair.of(e.getKey(), Suppliers.ofInstance(e.getValue())))
+                            .collect(Collectors.toMap(Pair::getKey, Pair::getValue)));
             return this;
         }
 
-        public List<Supplier<FunctionDefinition>> getFunctions() {
+        public Map<String, Supplier<FunctionDefinition>> getFunctions() {
             return functions;
         }
 
-        public int getNextFunctionIndex() {
-            return functions.size();
-        }
-
         public Builder setFunctionSuppliers(
-                Collection<Supplier<FunctionDefinition>> functions) {
+                Collection<Map.Entry<String, Supplier<FunctionDefinition>>> functions) {
             this.functions.clear();
-            this.functions.addAll(functions);
+            this.functions.putAll(ImmutableMap.copyOf(functions));
             return this;
         }
 
-        public Builder setFunctions(Collection<FunctionDefinition> functions) {
+        public Builder setFunctions(Collection<Map.Entry<String, FunctionDefinition>> functions) {
             this.functions.clear();
-            this.functions.addAll(functions.stream().map(Suppliers::ofInstance).collect(Collectors.toList()));
+            this.functions.putAll(functions.stream().map(e -> Pair.of(e.getKey(), Suppliers.ofInstance(e.getValue())))
+                    .collect(Collectors.toMap(Pair::getKey, Pair::getValue)));
             return this;
         }
 
-        public int addFunction(Supplier<FunctionDefinition> definition) {
-            functions.add(definition);
-            return functions.size() - 1;
+        public Builder addFunction(String name, Supplier<FunctionDefinition> definition) {
+            functions.put(name, definition);
+            return this;
         }
 
-        public int addFunction(FunctionDefinition definition) {
-            functions.add(Suppliers.ofInstance(definition));
-            return functions.size() - 1;
+        public Builder addFunction(String name, FunctionDefinition definition) {
+            functions.put(name, Suppliers.ofInstance(definition));
+            return this;
         }
 
         @SafeVarargs
-        public final Builder addFunctions(Supplier<FunctionDefinition>... definitions) {
-            functions.addAll(Arrays.asList(definitions));
+        public final Builder addFunctionSuppliers(Map.Entry<String, Supplier<FunctionDefinition>>... definitions) {
+            functions.putAll(Arrays.stream(definitions)
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
             return this;
         }
 
-        public Builder addFunctions(FunctionDefinition... definitions) {
-            functions.addAll(Arrays.stream(definitions).map(Suppliers::ofInstance).collect(Collectors.toList()));
+        @SafeVarargs
+        public final Builder addFunctions(Map.Entry<String, FunctionDefinition>... definitions) {
+            functions
+                    .putAll(Arrays.stream(definitions).map(e -> Pair.of(e.getKey(), Suppliers.ofInstance(e.getValue())))
+                            .collect(Collectors.toMap(Pair::getKey, Pair::getValue)));
             return this;
         }
 
-        public Builder addFunctionSuppliers(Collection<Supplier<FunctionDefinition>> definitions) {
-            functions.addAll(definitions);
+        public Builder addFunctionSuppliers(Collection<Map.Entry<String, Supplier<FunctionDefinition>>> definitions) {
+            functions.putAll(ImmutableMap.copyOf(definitions));
             return this;
         }
 
-        public Builder addFunctions(Collection<FunctionDefinition> definitions) {
-            functions.addAll(definitions.stream().map(Suppliers::ofInstance).collect(Collectors.toList()));
+        public Builder addFunctions(Collection<Map.Entry<String, FunctionDefinition>> definitions) {
+            functions.putAll(definitions.stream().map(e -> Pair.of(e.getKey(), Suppliers.ofInstance(e.getValue())))
+                    .collect(Collectors.toMap(Pair::getKey, Pair::getValue)));
             return this;
         }
     }

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/ir/instruction/FunctionCreate.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/ir/instruction/FunctionCreate.java
@@ -20,17 +20,17 @@ import java.util.List;
  * FunctionCreate(functionName, [ ** contextVariables ])
  */
 public class FunctionCreate implements IProceduralValue {
-    private int functionIndex;
+    private String functionName;
     private List<IProceduralValue> contextVariables;
 
-    private FunctionCreate(int functionIndex,
+    private FunctionCreate(String functionName,
                            List<IProceduralValue> contextVariables) {
-        this.functionIndex = functionIndex;
+        this.functionName = functionName;
         this.contextVariables = contextVariables;
     }
 
-    public int getFunctionIndex() {
-        return functionIndex;
+    public String getFunctionName() {
+        return functionName;
     }
 
     public List<IProceduralValue> getContextVariables() {
@@ -43,65 +43,64 @@ public class FunctionCreate implements IProceduralValue {
     }
 
     @Override
-    public <R> R accept(IValueVisitor<R> visitor)
-            throws FractalException {
+    public <R> R accept(IValueVisitor<R> visitor) throws FractalException {
         return visitor.visitFunctionCreate(this);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this, KFractalToStringStyle.KFRACTAL_TO_STRING_STYLE)
-                .append("functionIndex", functionIndex)
+                .append("functionName", functionName)
                 .append("contextVariables", contextVariables)
                 .toString();
     }
 
-    public static FunctionCreate create(int functionIndex) {
-        if (functionIndex < 0)
-            throw new IndexOutOfBoundsException("FunctionContextConstant index cannot be less than 0");
-        return new FunctionCreate(functionIndex, ImmutableList.of());
+    public static FunctionCreate create(String functionName) {
+        if (functionName == null)
+            throw new NullPointerException("FunctionName cannot be null");
+        return new FunctionCreate(functionName, ImmutableList.of());
     }
 
-    public static FunctionCreate create(int functionIndex,
+    public static FunctionCreate create(String functionName,
                                         IProceduralValue... contextVariables) {
-        if (functionIndex < 0)
-            throw new IndexOutOfBoundsException("FunctionContextConstant index cannot be less than 0");
-        return new FunctionCreate(functionIndex, ImmutableList.copyOf(contextVariables));
+        if (functionName == null)
+            throw new NullPointerException("FunctionName cannot be null");
+        return new FunctionCreate(functionName, ImmutableList.copyOf(contextVariables));
     }
 
-    public static FunctionCreate create(int functionIndex,
-                                        List<IProceduralValue> contextVariables) {
-        if (functionIndex < 0)
-            throw new IndexOutOfBoundsException("FunctionContextConstant index cannot be less than 0");
-        return new FunctionCreate(functionIndex, ImmutableList.copyOf(contextVariables));
+    public static FunctionCreate create(String functionName,
+                                        Iterable<IProceduralValue> contextVariables) {
+        if (functionName == null)
+            throw new NullPointerException("FunctionName cannot be null");
+        return new FunctionCreate(functionName, ImmutableList.copyOf(contextVariables));
     }
 
     public static class Builder {
-        private int functionIndex;
-        private List<IProceduralValue>
-                contextVariables = Lists.newArrayList();
+        private String functionName;
+        private List<IProceduralValue> contextVariables =
+                Lists.newArrayList();
 
         public Builder() {
         }
 
-        public Builder(int functionIndex,
+        public Builder(String functionName,
                        Collection<IProceduralValue> contextVariables) {
-            this.functionIndex = functionIndex;
+            this.functionName = functionName;
             this.contextVariables.addAll(contextVariables);
         }
 
         public FunctionCreate build() {
-            if (functionIndex < 0)
-                throw new IndexOutOfBoundsException("FunctionContextConstant index cannot be less than 0");
-            return new FunctionCreate(functionIndex, ImmutableList.copyOf(contextVariables));
+            if (functionName == null)
+                throw new IllegalStateException("No functionName specified");
+            return new FunctionCreate(functionName, ImmutableList.copyOf(contextVariables));
         }
 
-        public int getFunctionIndex() {
-            return functionIndex;
+        public String getFunctionName() {
+            return functionName;
         }
 
-        public Builder setFunctionIndex(int functionIndex) {
-            this.functionIndex = functionIndex;
+        public Builder setFunctionName(String functionName) {
+            this.functionName = functionName;
             return this;
         }
 
@@ -110,9 +109,9 @@ public class FunctionCreate implements IProceduralValue {
         }
 
         public Builder setContextVariables(
-                List<IProceduralValue> contextVariables) {
+                Collection<IProceduralValue> contextVariables) {
             this.contextVariables.clear();
-            contextVariables.addAll(contextVariables);
+            this.contextVariables.addAll(contextVariables);
             return this;
         }
 
@@ -121,12 +120,14 @@ public class FunctionCreate implements IProceduralValue {
             return this;
         }
 
-        public Builder addContextVariables(IProceduralValue... contextVariables) {
+        public Builder addContextVariables(
+                IProceduralValue... contextVariables) {
             this.contextVariables.addAll(Arrays.asList(contextVariables));
             return this;
         }
 
-        public Builder addContextVariables(Collection<IProceduralValue> contextVariables) {
+        public Builder addContextVariables(
+                Collection<IProceduralValue> contextVariables) {
             this.contextVariables.addAll(contextVariables);
             return this;
         }

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/ir/instruction/GlobalGet.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/ir/instruction/GlobalGet.java
@@ -8,14 +8,14 @@ import com.kneelawk.kfractal.util.KFractalToStringStyle;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 public class GlobalGet implements IProceduralValue {
-    private int globalIndex;
+    private String globalName;
 
-    private GlobalGet(int globalIndex) {
-        this.globalIndex = globalIndex;
+    private GlobalGet(String globalName) {
+        this.globalName = globalName;
     }
 
-    public int getGlobalIndex() {
-        return globalIndex;
+    public String getGlobalName() {
+        return globalName;
     }
 
     @Override
@@ -24,42 +24,45 @@ public class GlobalGet implements IProceduralValue {
     }
 
     @Override
-    public <R> R accept(IValueVisitor<R> visitor)
-            throws FractalException {
+    public <R> R accept(IValueVisitor<R> visitor) throws FractalException {
         return visitor.visitGlobalGet(this);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this, KFractalToStringStyle.KFRACTAL_TO_STRING_STYLE)
-                .append("globalIndex", globalIndex)
+                .append("globalName", globalName)
                 .toString();
     }
 
-    public static GlobalGet create(int globalIndex) {
-        return new GlobalGet(globalIndex);
+    public static GlobalGet create(String globalName) {
+        if (globalName == null)
+            throw new NullPointerException("GlobalName cannot be null");
+        return new GlobalGet(globalName);
     }
 
     public static class Builder {
-        private int globalIndex;
+        private String globalName;
 
         public Builder() {
         }
 
-        public Builder(int globalIndex) {
-            this.globalIndex = globalIndex;
+        public Builder(String globalName) {
+            this.globalName = globalName;
         }
 
         public GlobalGet build() {
-            return new GlobalGet(globalIndex);
+            if (globalName == null)
+                throw new IllegalStateException("No globalName specified");
+            return new GlobalGet(globalName);
         }
 
-        public int getGlobalIndex() {
-            return globalIndex;
+        public String getGlobalName() {
+            return globalName;
         }
 
-        public Builder setGlobalIndex(int globalIndex) {
-            this.globalIndex = globalIndex;
+        public Builder setGlobalName(String globalName) {
+            this.globalName = globalName;
             return this;
         }
     }

--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/ir/instruction/GlobalSet.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/ir/instruction/GlobalSet.java
@@ -8,16 +8,16 @@ import com.kneelawk.kfractal.util.KFractalToStringStyle;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 public class GlobalSet implements IProceduralValue {
-    private int globalIndex;
+    private String globalName;
     private IProceduralValue data;
 
-    private GlobalSet(int globalIndex, IProceduralValue data) {
-        this.globalIndex = globalIndex;
+    private GlobalSet(String globalName, IProceduralValue data) {
+        this.globalName = globalName;
         this.data = data;
     }
 
-    public int getGlobalIndex() {
-        return globalIndex;
+    public String getGlobalName() {
+        return globalName;
     }
 
     public IProceduralValue getData() {
@@ -30,49 +30,53 @@ public class GlobalSet implements IProceduralValue {
     }
 
     @Override
-    public <R> R accept(IValueVisitor<R> visitor)
-            throws FractalException {
+    public <R> R accept(IValueVisitor<R> visitor) throws FractalException {
         return visitor.visitGlobalSet(this);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this, KFractalToStringStyle.KFRACTAL_TO_STRING_STYLE)
-                .append("globalIndex", globalIndex)
+                .append("globalName", globalName)
                 .append("data", data)
                 .toString();
     }
 
-    public static GlobalSet create(int globalIndex, IProceduralValue data) {
+    public static GlobalSet create(String globalName,
+                                   IProceduralValue data) {
+        if (globalName == null)
+            throw new NullPointerException("GlobalName cannot be null");
         if (data == null)
             throw new NullPointerException("Data cannot be null");
-        return new GlobalSet(globalIndex, data);
+        return new GlobalSet(globalName, data);
     }
 
     public static class Builder {
-        private int globalIndex;
+        private String globalName;
         private IProceduralValue data;
 
         public Builder() {
         }
 
-        public Builder(int globalIndex, IProceduralValue data) {
-            this.globalIndex = globalIndex;
+        public Builder(String globalName, IProceduralValue data) {
+            this.globalName = globalName;
             this.data = data;
         }
 
         public GlobalSet build() {
+            if (globalName == null)
+                throw new IllegalStateException("No globalName specified");
             if (data == null)
                 throw new IllegalStateException("No data specified");
-            return new GlobalSet(globalIndex, data);
+            return new GlobalSet(globalName, data);
         }
 
-        public int getGlobalIndex() {
-            return globalIndex;
+        public String getGlobalName() {
+            return globalName;
         }
 
-        public Builder setGlobalIndex(int globalIndex) {
-            this.globalIndex = globalIndex;
+        public Builder setGlobalName(String globalName) {
+            this.globalName = globalName;
             return this;
         }
 

--- a/generatorutil/src/main/java/com/kneelawk/kfractal/generator/util/ProceduralValuePrinter.java
+++ b/generatorutil/src/main/java/com/kneelawk/kfractal/generator/util/ProceduralValuePrinter.java
@@ -85,13 +85,13 @@ class ProceduralValuePrinter implements IProceduralValueVisitor<Void> {
 
     @Override
     public Void visitGlobalGet(GlobalGet globalGet) {
-        builder.append("GlobalGet(").append(globalGet.getGlobalIndex()).append(")");
+        builder.append("GlobalGet(\"").append(globalGet.getGlobalName()).append("\")");
         return null;
     }
 
     @Override
     public Void visitGlobalSet(GlobalSet globalSet) throws FractalException {
-        builder.append("GlobalSet(").append(globalSet.getGlobalIndex()).append(", ");
+        builder.append("GlobalSet(\"").append(globalSet.getGlobalName()).append("\", ");
         globalSet.getData().accept(this);
         builder.append(")");
         return null;
@@ -439,7 +439,7 @@ class ProceduralValuePrinter implements IProceduralValueVisitor<Void> {
 
     @Override
     public Void visitFunctionCreate(FunctionCreate functionCreate) throws FractalException {
-        builder.append("FunctionCreate(").append(functionCreate.getFunctionIndex()).append(", [ ");
+        builder.append("FunctionCreate(\"").append(functionCreate.getFunctionName()).append("\", [ ");
         boolean first = true;
         for (IProceduralValue input : functionCreate.getContextVariables()) {
             if (!first)

--- a/generatorutil/src/main/java/com/kneelawk/kfractal/generator/util/ProgramPrinter.java
+++ b/generatorutil/src/main/java/com/kneelawk/kfractal/generator/util/ProgramPrinter.java
@@ -8,6 +8,7 @@ import com.kneelawk.kfractal.generator.api.ir.phi.PhiBranch;
 import com.kneelawk.kfractal.util.StringUtils;
 
 import java.util.List;
+import java.util.Map;
 
 public class ProgramPrinter {
     public static String printProgram(Program program) {
@@ -15,13 +16,13 @@ public class ProgramPrinter {
         builder.append("Program(").append(System.lineSeparator());
         builder.append("[");
         boolean first = true;
-        for (int i = 0; i < program.getGlobalVariables().size(); i++) {
-            GlobalDeclaration variable = program.getGlobalVariables().get(i);
+        for (Map.Entry<String, GlobalDeclaration> entry : program.getGlobalVariables().entrySet()) {
+            GlobalDeclaration variable = entry.getValue();
             if (!first)
                 builder.append(",");
             builder.append(System.lineSeparator());
             StringUtils.indent(builder, 1);
-            builder.append(i).append("=");
+            builder.append('"').append(entry.getKey()).append("\"=");
             printGlobalDeclaration(builder, variable);
             first = false;
         }
@@ -33,13 +34,13 @@ public class ProgramPrinter {
         builder.append("],").append(System.lineSeparator());
         builder.append("[");
         first = true;
-        for (int i = 0; i < program.getFunctions().size(); i++) {
-            FunctionDefinition function = program.getFunctions().get(i);
+        for (Map.Entry<String, FunctionDefinition> entry : program.getFunctions().entrySet()) {
+            FunctionDefinition function = entry.getValue();
             if (!first)
                 builder.append(",");
             builder.append(System.lineSeparator());
             StringUtils.indent(builder, 1);
-            builder.append(i).append("=");
+            builder.append('"').append(entry.getKey()).append("\"=");
             printFunctionDefinition(builder, function);
             first = false;
         }

--- a/generatorvalidation/src/main/java/com/kneelawk/kfractal/generator/validation/ProgramValidator.java
+++ b/generatorvalidation/src/main/java/com/kneelawk/kfractal/generator/validation/ProgramValidator.java
@@ -12,9 +12,9 @@ import java.util.Set;
 
 public class ProgramValidator {
     public static void checkValidity(Program program) throws FractalException {
-        checkGlobals(program.getGlobalVariables());
+        checkGlobals(program.getGlobalVariables().values());
 
-        for (FunctionDefinition function : program.getFunctions()) {
+        for (FunctionDefinition function : program.getFunctions().values()) {
             checkFunction(function, program);
         }
     }

--- a/generatorvalidation/src/main/java/com/kneelawk/kfractal/generator/validation/TypeLookupValueVisitor.java
+++ b/generatorvalidation/src/main/java/com/kneelawk/kfractal/generator/validation/TypeLookupValueVisitor.java
@@ -108,9 +108,12 @@ class TypeLookupValueVisitor implements IValueVisitor<ValueType> {
     }
 
     @Override
-    public ValueType visitGlobalGet(GlobalGet globalGet) {
-        return
-                context.getProgram().getGlobalVariables().get(globalGet.getGlobalIndex()).getType();
+    public ValueType visitGlobalGet(GlobalGet globalGet) throws FractalException {
+        String name = globalGet.getGlobalName();
+        if (!context.getProgram().getGlobalVariables().containsKey(name)) {
+            throw new MissingVariableReferenceException("Cannot determine the type of a global variable that does not exist");
+        }
+        return context.getProgram().getGlobalVariables().get(name).getType();
     }
 
     @Override
@@ -295,12 +298,12 @@ class TypeLookupValueVisitor implements IValueVisitor<ValueType> {
 
     @Override
     public ValueType visitFunctionCreate(FunctionCreate functionCreate) throws FractalException {
-        int index = functionCreate.getFunctionIndex();
-        if (index < 0 || index > context.getProgram().getFunctions().size()) {
+        String name = functionCreate.getFunctionName();
+        if (!context.getProgram().getFunctions().containsKey(name)) {
             throw new MissingFunctionReferenceException("Cannot determine type of a function that does not exist");
         }
 
-        FunctionDefinition function = context.getProgram().getFunctions().get(functionCreate.getFunctionIndex());
+        FunctionDefinition function = context.getProgram().getFunctions().get(name);
         ImmutableList.Builder<ValueType> arguments = ImmutableList.builder();
         for (ArgumentDeclaration argument : function.getArguments()) {
             arguments.add(argument.getType());

--- a/generatorvalidation/src/main/java/com/kneelawk/kfractal/generator/validation/ValidatingProceduralValueVisitor.java
+++ b/generatorvalidation/src/main/java/com/kneelawk/kfractal/generator/validation/ValidatingProceduralValueVisitor.java
@@ -195,20 +195,19 @@ class ValidatingProceduralValueVisitor implements IProceduralValueVisitor<Valida
 
     @Override
     public ValidatingVisitorResult visitGlobalGet(GlobalGet globalGet) throws FractalException {
-        if (globalGet.getGlobalIndex() < 0 ||
-                globalGet.getGlobalIndex() >= context.getProgram().getGlobalVariables().size()) {
-            throw new FractalIRValidationException("Invalid global index");
+        if (!context.getProgram().getGlobalVariables().containsKey(globalGet.getGlobalName())) {
+            throw new MissingVariableReferenceException("Invalid global name");
         }
         return ValidatingVisitorResult.create();
     }
 
     @Override
     public ValidatingVisitorResult visitGlobalSet(GlobalSet globalSet) throws FractalException {
-        int globalIndex = globalSet.getGlobalIndex();
-        if (globalIndex < 0 || globalIndex >= context.getProgram().getGlobalVariables().size()) {
-            throw new FractalIRValidationException("Invalid global index");
+        String globalName = globalSet.getGlobalName();
+        if (!context.getProgram().getGlobalVariables().containsKey(globalName)) {
+            throw new MissingVariableReferenceException("Invalid global name");
         }
-        validValueTypeIfTrue(context.getProgram().getGlobalVariables().get(globalIndex).getType()
+        validValueTypeIfTrue(context.getProgram().getGlobalVariables().get(globalName).getType()
                         .isAssignableFrom(cache.getType(globalSet.getData(), context)),
                 "GlobalSet global and data are of incompatible types");
         tryVisit(globalSet, globalSet.getData());
@@ -570,13 +569,13 @@ class ValidatingProceduralValueVisitor implements IProceduralValueVisitor<Valida
 
     @Override
     public ValidatingVisitorResult visitFunctionCreate(FunctionCreate functionCreate) throws FractalException {
-        int functionIndex = functionCreate.getFunctionIndex();
-        if (functionIndex < 0 || functionIndex >= context.getProgram().getFunctions().size()) {
+        String functionName = functionCreate.getFunctionName();
+        if (!context.getProgram().getFunctions().containsKey(functionName)) {
             throw new MissingFunctionReferenceException("Invalid function create function index");
         }
 
         // compare context variable types
-        FunctionDefinition target = context.getProgram().getFunctions().get(functionIndex);
+        FunctionDefinition target = context.getProgram().getFunctions().get(functionName);
         List<ArgumentDeclaration> targetContextVariables = target.getContextVariables();
         List<IProceduralValue> createContextVariables = functionCreate.getContextVariables();
         int targetContextVariablesSize = targetContextVariables.size();

--- a/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/CyclicInstructionTests.java
+++ b/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/CyclicInstructionTests.java
@@ -29,7 +29,7 @@ public class CyclicInstructionTests {
 
         block.addValue(not);
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 

--- a/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/FunctionValidationTests.java
+++ b/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/FunctionValidationTests.java
@@ -21,7 +21,7 @@ class FunctionValidationTests {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 
@@ -35,7 +35,7 @@ class FunctionValidationTests {
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
         function.addBlock(new BasicBlock.Builder().build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 
@@ -54,7 +54,7 @@ class FunctionValidationTests {
         block.addValue(Return.create(createConstant(programBuilder, block, valueTypes.right)));
 
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 

--- a/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/IOValidationTests.java
+++ b/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/IOValidationTests.java
@@ -31,10 +31,10 @@ class IOValidationTests {
         FunctionDefinition.Builder functionBuilder = new FunctionDefinition.Builder();
         functionBuilder.setReturnType(ValueTypes.VOID);
         BasicBlock.Builder block = new BasicBlock.Builder();
-        block.addValue(FunctionCall.create(FunctionCreate.create(100)));
+        block.addValue(FunctionCall.create(FunctionCreate.create("missing")));
         block.addValue(Return.create(VoidConstant.INSTANCE));
         functionBuilder.addBlock(block.build());
-        programBuilder.addFunction(functionBuilder.build());
+        programBuilder.addFunction("f", functionBuilder.build());
 
         Program program = programBuilder.build();
 
@@ -53,15 +53,15 @@ class IOValidationTests {
         BasicBlock.Builder gBlock = new BasicBlock.Builder();
         gBlock.addValue(Return.create(ComplexAdd.create(ga, ComplexConstant.create(new Complex(0, 2)))));
         gFunctionBuilder.addBlock(gBlock.build());
-        int gIndex = programBuilder.addFunction(gFunctionBuilder.build());
+        programBuilder.addFunction("g", gFunctionBuilder.build());
 
         FunctionDefinition.Builder fFunctionBuilder = new FunctionDefinition.Builder();
         fFunctionBuilder.setReturnType(ValueTypes.VOID);
         BasicBlock.Builder fBlock = new BasicBlock.Builder();
-        fBlock.addValue(FunctionCreate.create(gIndex));
+        fBlock.addValue(FunctionCreate.create("g"));
         fBlock.addValue(Return.create(VoidConstant.INSTANCE));
         fFunctionBuilder.addBlock(fBlock.build());
-        programBuilder.addFunction(fFunctionBuilder.build());
+        programBuilder.addFunction("f", fFunctionBuilder.build());
 
         // test the validator
         assertThrows(IncompatibleFunctionContextException.class,
@@ -78,15 +78,15 @@ class IOValidationTests {
         BasicBlock.Builder gBlock = new BasicBlock.Builder();
         gBlock.addValue(Return.create(ComplexAdd.create(ga, ComplexConstant.create(new Complex(0, 2)))));
         gFunctionBuilder.addBlock(gBlock.build());
-        int gIndex = programBuilder.addFunction(gFunctionBuilder.build());
+        programBuilder.addFunction("g", gFunctionBuilder.build());
 
         FunctionDefinition.Builder fFunctionBuilder = new FunctionDefinition.Builder();
         fFunctionBuilder.setReturnType(ValueTypes.VOID);
         BasicBlock.Builder fBlock = new BasicBlock.Builder();
-        fBlock.addValue(FunctionCreate.create(gIndex, ImmutableList.of(ComplexConstant.create(new Complex(2, 0)))));
+        fBlock.addValue(FunctionCreate.create("g", ImmutableList.of(ComplexConstant.create(new Complex(2, 0)))));
         fBlock.addValue(Return.create(VoidConstant.INSTANCE));
         fFunctionBuilder.addBlock(fBlock.build());
-        programBuilder.addFunction(fFunctionBuilder.build());
+        programBuilder.addFunction("f", fFunctionBuilder.build());
 
         // test the validator
         assertDoesNotThrow(() -> ProgramValidator.checkValidity(programBuilder.build()));

--- a/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/InstructionValidationFunctionTests.java
+++ b/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/InstructionValidationFunctionTests.java
@@ -95,18 +95,18 @@ class InstructionValidationFunctionTests {
         otherBlock.addValue(
                 Return.create(createConstant(programBuilder, otherBlock, functionType.getReturnType())));
         otherFunction.addBlock(otherBlock.build());
-        int gIndex = programBuilder.addFunction(otherFunction.build());
+        programBuilder.addFunction("g", otherFunction.build());
 
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
         BasicBlock.Builder block = new BasicBlock.Builder();
         block.addValue(FunctionCall
-                .create(FunctionCreate.create(gIndex),
+                .create(FunctionCreate.create("g"),
                         functionAndArgs.getRight().stream().map(v -> createConstant(programBuilder, block, v))
                                 .collect(Collectors.toList())));
         block.addValue(Return.create(VoidConstant.INSTANCE));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 
@@ -123,7 +123,7 @@ class InstructionValidationFunctionTests {
         block.addValue(FunctionCall.create(NullFunction.INSTANCE));
         block.addValue(Return.create(VoidConstant.INSTANCE));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 
@@ -144,18 +144,18 @@ class InstructionValidationFunctionTests {
         otherBlock.addValue(
                 Return.create(createConstant(programBuilder, otherBlock, functionType.getReturnType())));
         otherFunction.addBlock(otherBlock.build());
-        int gIndex = programBuilder.addFunction(otherFunction.build());
+        programBuilder.addFunction("g", otherFunction.build());
 
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
         BasicBlock.Builder block = new BasicBlock.Builder();
         block.addValue(FunctionCall
-                .create(FunctionCreate.create(gIndex),
+                .create(FunctionCreate.create("g"),
                         functionAndArgs.getRight().stream().map(v -> createConstant(programBuilder, block, v))
                                 .collect(Collectors.toList())));
         block.addValue(Return.create(VoidConstant.INSTANCE));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 
@@ -172,16 +172,16 @@ class InstructionValidationFunctionTests {
         BasicBlock.Builder otherBlock = new BasicBlock.Builder();
         otherBlock.addValue(Return.create(VoidConstant.INSTANCE));
         otherFunction.addBlock(otherBlock.build());
-        int gIndex = programBuilder.addFunction(otherFunction.build());
+        programBuilder.addFunction("g", otherFunction.build());
 
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
         BasicBlock.Builder block = new BasicBlock.Builder();
         block.addValue(FunctionCall
-                .create(FunctionCreate.create(gIndex)));
+                .create(FunctionCreate.create("g")));
         block.addValue(Return.create(VoidConstant.INSTANCE));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 

--- a/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/InstructionValidationPointerTests.java
+++ b/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/InstructionValidationPointerTests.java
@@ -90,7 +90,7 @@ public class InstructionValidationPointerTests {
         block.addValue(PointerAllocate.create(valueType));
         block.addValue(Return.create(VoidConstant.INSTANCE));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 
@@ -108,7 +108,7 @@ public class InstructionValidationPointerTests {
         block.addValue(PointerAllocate.create(valueType));
         block.addValue(Return.create(VoidConstant.INSTANCE));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 
@@ -125,7 +125,7 @@ public class InstructionValidationPointerTests {
         block.addValue(PointerFree.create(createConstant(programBuilder, block, valueType)));
         block.addValue(Return.create(VoidConstant.INSTANCE));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 
@@ -142,7 +142,7 @@ public class InstructionValidationPointerTests {
         block.addValue(PointerFree.create(NullPointer.INSTANCE));
         block.addValue(Return.create(VoidConstant.INSTANCE));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 
@@ -160,7 +160,7 @@ public class InstructionValidationPointerTests {
         block.addValue(PointerFree.create(createConstant(programBuilder, block, valueType)));
         block.addValue(Return.create(VoidConstant.INSTANCE));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 
@@ -196,7 +196,7 @@ public class InstructionValidationPointerTests {
                         createConstant(programBuilder, block, valueTypes.get(1))));
         block.addValue(Return.create(VoidConstant.INSTANCE));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 
@@ -217,7 +217,7 @@ public class InstructionValidationPointerTests {
         block.addValue(PointerFree.create(p));
         block.addValue(Return.create(VoidConstant.INSTANCE));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 
@@ -236,7 +236,7 @@ public class InstructionValidationPointerTests {
                 PointerSet.create(NullPointer.INSTANCE, createConstant(programBuilder, block, valueType)));
         block.addValue(Return.create(VoidConstant.INSTANCE));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 
@@ -256,7 +256,7 @@ public class InstructionValidationPointerTests {
                 .create(p, createConstant(programBuilder, block, valueTypes.getRight())));
         block.addValue(Return.create(VoidConstant.INSTANCE));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 

--- a/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/InstructionValidationReturnTests.java
+++ b/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/InstructionValidationReturnTests.java
@@ -23,7 +23,7 @@ class InstructionValidationReturnTests {
         BasicBlock.Builder block = new BasicBlock.Builder();
         block.addValue(Return.create(createConstant(programBuilder, block, valueTypes.getRight())));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 
@@ -40,7 +40,7 @@ class InstructionValidationReturnTests {
         BasicBlock.Builder block = new BasicBlock.Builder();
         block.addValue(Return.create(createConstant(programBuilder, block, valueType)));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 
@@ -55,7 +55,7 @@ class InstructionValidationReturnTests {
         BasicBlock.Builder block = new BasicBlock.Builder();
         block.addValue(Return.create(VoidConstant.INSTANCE));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 

--- a/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/ValueTypeAsserts.java
+++ b/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/ValueTypeAsserts.java
@@ -21,7 +21,7 @@ class ValueTypeAsserts {
                 createConstant(programBuilder, block, argumentTypes.get(1))));
         block.addValue(Return.create(VoidConstant.INSTANCE));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 
@@ -38,7 +38,7 @@ class ValueTypeAsserts {
                 createConstant(programBuilder, block, argumentTypes.get(1))));
         block.addValue(Return.create(VoidConstant.INSTANCE));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 
@@ -53,7 +53,7 @@ class ValueTypeAsserts {
         block.addValue(creator.create(createConstant(programBuilder, block, argumentType)));
         block.addValue(Return.create(VoidConstant.INSTANCE));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 
@@ -69,7 +69,7 @@ class ValueTypeAsserts {
         block.addValue(creator.create(createConstant(programBuilder, block, argumentType)));
         block.addValue(Return.create(VoidConstant.INSTANCE));
         function.addBlock(block.build());
-        programBuilder.addFunction(function.build());
+        programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 

--- a/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/ValueTypeUtils.java
+++ b/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/ValueTypeUtils.java
@@ -1,5 +1,6 @@
 package com.kneelawk.kfractal.generator.validation;
 
+import com.google.common.collect.ImmutableSet;
 import com.kneelawk.kfractal.generator.api.ir.*;
 import com.kneelawk.kfractal.generator.api.ir.attribute.IGlobalAttribute;
 import com.kneelawk.kfractal.generator.api.ir.constant.*;
@@ -10,10 +11,28 @@ import com.kneelawk.kfractal.generator.api.ir.instruction.Return;
 import com.kneelawk.kfractal.generator.api.ir.reference.InstructionReference;
 import org.apache.commons.math3.complex.Complex;
 
+import java.util.Set;
+
 public class ValueTypeUtils {
+    private static String findFunctionName(Set<String> usedNames) {
+        int index = 0;
+        while (usedNames.contains("func_" + index)) {
+            index++;
+        }
+        return "func_" + index;
+    }
+
+    private static String findGlobalName(Set<String> usedNames) {
+        int index = 0;
+        while (usedNames.contains("global_" + index)) {
+            index++;
+        }
+        return "global_" + index;
+    }
+
     static IProceduralValue createConstant(Program.Builder programBuilder,
                                            BasicBlock.Builder blockBuilder,
-                                           int functionOffset, int globalVariableOffset, int localVariableOffset,
+                                           Set<String> usedFunctionNames, Set<String> usedGlobalNames,
                                            ValueType type) {
         if (ValueTypes.isVoid(type)) {
             return VoidConstant.INSTANCE;
@@ -31,33 +50,38 @@ public class ValueTypeUtils {
             } else {
                 ValueTypes.FunctionType functionType = ValueTypes.toFunction(type);
                 FunctionDefinition.Builder newFunction = new FunctionDefinition.Builder();
+                String functionName = findFunctionName(
+                        ImmutableSet.<String>builder().addAll(programBuilder.getFunctions().keySet())
+                                .addAll(usedFunctionNames).build());
                 newFunction.setReturnType(functionType.getReturnType());
                 for (ValueType argumentType : functionType.getArgumentTypes()) {
                     newFunction.addArgument(ArgumentDeclaration.create(argumentType));
                 }
 
                 BasicBlock.Builder newBlock = new BasicBlock.Builder();
-                newBlock.addValue(
-                        Return.create(createConstant(programBuilder, newBlock,
-                                functionOffset, globalVariableOffset, 0,
-                                functionType.getReturnType())));
+                newBlock.addValue(Return.create(createConstant(programBuilder, newBlock,
+                        ImmutableSet.<String>builder().addAll(usedFunctionNames).add(functionName).build(),
+                        usedGlobalNames, functionType.getReturnType())));
 
                 newFunction.addBlock(newBlock.build());
-                int functionIndex = programBuilder.addFunction(newFunction.build());
-                return FunctionCreate.create(functionIndex + functionOffset);
+                programBuilder.addFunction(functionName, newFunction.build());
+                return FunctionCreate.create(functionName);
             }
         } else if (ValueTypes.isPointer(type)) {
             if (ValueTypes.isNullPointer(type)) {
                 return NullPointer.INSTANCE;
             } else {
                 // TODO: Stop relying on preallocated variables
-                int pointer =
-                        programBuilder.addGlobalVariable(GlobalDeclaration.create(type, IGlobalAttribute.PREALLOCATED))
-                                + globalVariableOffset;
-                InstructionReference reference = blockBuilder.addValue(GlobalGet.create(pointer));
+                String globalName = findGlobalName(
+                        ImmutableSet.<String>builder().addAll(programBuilder.getGlobalVariables().keySet())
+                                .addAll(usedGlobalNames).build());
+                programBuilder
+                        .addGlobalVariable(globalName, GlobalDeclaration.create(type, IGlobalAttribute.PREALLOCATED));
+                InstructionReference reference = blockBuilder.addValue(GlobalGet.create(globalName));
                 blockBuilder.addValue(PointerSet.create(reference,
-                        createConstant(programBuilder, blockBuilder, functionOffset, globalVariableOffset,
-                                localVariableOffset, ValueTypes.toPointer(type).getPointerType())));
+                        createConstant(programBuilder, blockBuilder, usedFunctionNames,
+                                ImmutableSet.<String>builder().addAll(usedGlobalNames).add(globalName).build(),
+                                ValueTypes.toPointer(type).getPointerType())));
                 return reference;
             }
         } else {
@@ -67,6 +91,6 @@ public class ValueTypeUtils {
 
     static IProceduralValue createConstant(Program.Builder programBuilder, BasicBlock.Builder blockBuilder,
                                            ValueType type) {
-        return createConstant(programBuilder, blockBuilder, 0, 0, 0, type);
+        return createConstant(programBuilder, blockBuilder, ImmutableSet.of(), ImmutableSet.of(), type);
     }
 }

--- a/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/VariableValidationTests.java
+++ b/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/VariableValidationTests.java
@@ -21,7 +21,7 @@ class VariableValidationTests {
     @Test
     void testIllegalVoidVariableType() {
         Program.Builder program = new Program.Builder();
-        program.addGlobalVariable(GlobalDeclaration.create(ValueTypes.VOID));
+        program.addGlobalVariable("v", GlobalDeclaration.create(ValueTypes.VOID));
 
         assertThrows(IllegalVariableTypeException.class, () -> ProgramValidator.checkValidity(program.build()));
     }
@@ -29,7 +29,7 @@ class VariableValidationTests {
     @Test
     void testIllegalNullFunctionVariableType() {
         Program.Builder program = new Program.Builder();
-        program.addGlobalVariable(GlobalDeclaration.create(ValueTypes.NULL_FUNCTION));
+        program.addGlobalVariable("v", GlobalDeclaration.create(ValueTypes.NULL_FUNCTION));
 
         assertThrows(IllegalVariableTypeException.class, () -> ProgramValidator.checkValidity(program.build()));
     }
@@ -37,7 +37,7 @@ class VariableValidationTests {
     @Test
     void testIllegalNullPointerVariableType() {
         Program.Builder program = new Program.Builder();
-        program.addGlobalVariable(GlobalDeclaration.create(ValueTypes.NULL_POINTER));
+        program.addGlobalVariable("v", GlobalDeclaration.create(ValueTypes.NULL_POINTER));
 
         assertThrows(IllegalVariableTypeException.class, () -> ProgramValidator.checkValidity(program.build()));
     }
@@ -46,7 +46,7 @@ class VariableValidationTests {
     @MethodSource("nonPointerValueTypes")
     void testIllegalPreallocatedAnnotation(ValueType variableType) {
         Program.Builder program = new Program.Builder();
-        program.addGlobalVariable(
+        program.addGlobalVariable("v",
                 GlobalDeclaration.create(variableType, ImmutableSet.of(IGlobalAttribute.PREALLOCATED)));
 
         assertThrows(IllegalVariableAttributeException.class, () -> ProgramValidator.checkValidity(program.build()));
@@ -60,7 +60,7 @@ class VariableValidationTests {
     @ArgumentsSource(VariableValueTypesProvider.class)
     void testVariableDeclaration(ValueType variableType) {
         Program.Builder program = new Program.Builder();
-        program.addGlobalVariable(GlobalDeclaration.create(variableType));
+        program.addGlobalVariable("v", GlobalDeclaration.create(variableType));
 
         assertDoesNotThrow(() -> ProgramValidator.checkValidity(program.build()));
     }


### PR DESCRIPTION
This effectively reverts part of the no-variable-names patch. This pull request is designed to re-introduce variable names but only for global variables and functions. The rest of the program structure is unaffected. This should fix #50.