### PR TITLE
Validation test correct basicblock

### DIFF
--- a/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/ir/BasicBlock.java
+++ b/generatorapi/src/main/java/com/kneelawk/kfractal/generator/api/ir/BasicBlock.java
@@ -67,18 +67,10 @@ public class BasicBlock {
     public static class Builder {
         private List<Supplier<Phi>> phis = Lists.newArrayList();
         private List<Supplier<IProceduralValue>> body = Lists.newArrayList();
-        private int blockIndex = 0;
-
-        public Builder() {
-        }
+        private int blockIndex;
 
         public Builder(int blockIndex) {
             this.blockIndex = blockIndex;
-        }
-
-        public Builder(Collection<Supplier<Phi>> phis, Collection<Supplier<IProceduralValue>> body) {
-            this.phis.addAll(phis);
-            this.body.addAll(body);
         }
 
         public Builder(Collection<Supplier<Phi>> phis, Collection<Supplier<IProceduralValue>> body, int blockIndex) {

--- a/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/CyclicInstructionTests.java
+++ b/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/CyclicInstructionTests.java
@@ -19,7 +19,7 @@ public class CyclicInstructionTests {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
 
         // mimic mutability
         BoolNot not = BoolNot.create(VoidConstant.INSTANCE);
@@ -28,11 +28,12 @@ public class CyclicInstructionTests {
         input.set(not, BoolNot.create(not));
 
         block.addValue(not);
-        function.addBlock(block.build());
+
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
 
-        assertThrows(CyclicProceduralInstructionException.class, () -> ProgramValidator.checkValidity(program), () -> ProgramPrinter.printProgram(program));
+        assertThrows(CyclicProceduralInstructionException.class, () -> ProgramValidator.checkValidity(program),
+                () -> ProgramPrinter.printProgram(program));
     }
 }

--- a/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/FunctionValidationTests.java
+++ b/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/FunctionValidationTests.java
@@ -34,7 +34,7 @@ class FunctionValidationTests {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        function.addBlock(new BasicBlock.Builder().build());
+        function.addBlock();
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
@@ -50,10 +50,9 @@ class FunctionValidationTests {
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(valueTypes.left);
 
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         block.addValue(Return.create(createConstant(programBuilder, block, valueTypes.right)));
 
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();

--- a/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/IOValidationTests.java
+++ b/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/IOValidationTests.java
@@ -30,10 +30,9 @@ class IOValidationTests {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder functionBuilder = new FunctionDefinition.Builder();
         functionBuilder.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = functionBuilder.addBlock();
         block.addValue(FunctionCall.create(FunctionCreate.create("missing")));
         block.addValue(Return.create(VoidConstant.INSTANCE));
-        functionBuilder.addBlock(block.build());
         programBuilder.addFunction("f", functionBuilder.build());
 
         Program program = programBuilder.build();
@@ -50,17 +49,15 @@ class IOValidationTests {
         FunctionDefinition.Builder gFunctionBuilder = new FunctionDefinition.Builder();
         gFunctionBuilder.setReturnType(ValueTypes.COMPLEX);
         var ga = gFunctionBuilder.addContextVariable(ArgumentDeclaration.create(ValueTypes.COMPLEX));
-        BasicBlock.Builder gBlock = new BasicBlock.Builder();
+        BasicBlock.Builder gBlock = gFunctionBuilder.addBlock();
         gBlock.addValue(Return.create(ComplexAdd.create(ga, ComplexConstant.create(new Complex(0, 2)))));
-        gFunctionBuilder.addBlock(gBlock.build());
         programBuilder.addFunction("g", gFunctionBuilder.build());
 
         FunctionDefinition.Builder fFunctionBuilder = new FunctionDefinition.Builder();
         fFunctionBuilder.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder fBlock = new BasicBlock.Builder();
+        BasicBlock.Builder fBlock = fFunctionBuilder.addBlock();
         fBlock.addValue(FunctionCreate.create("g"));
         fBlock.addValue(Return.create(VoidConstant.INSTANCE));
-        fFunctionBuilder.addBlock(fBlock.build());
         programBuilder.addFunction("f", fFunctionBuilder.build());
 
         // test the validator
@@ -75,17 +72,15 @@ class IOValidationTests {
         FunctionDefinition.Builder gFunctionBuilder = new FunctionDefinition.Builder();
         gFunctionBuilder.setReturnType(ValueTypes.COMPLEX);
         var ga = gFunctionBuilder.addContextVariable(ArgumentDeclaration.create(ValueTypes.COMPLEX));
-        BasicBlock.Builder gBlock = new BasicBlock.Builder();
+        BasicBlock.Builder gBlock = gFunctionBuilder.addBlock();
         gBlock.addValue(Return.create(ComplexAdd.create(ga, ComplexConstant.create(new Complex(0, 2)))));
-        gFunctionBuilder.addBlock(gBlock.build());
         programBuilder.addFunction("g", gFunctionBuilder.build());
 
         FunctionDefinition.Builder fFunctionBuilder = new FunctionDefinition.Builder();
         fFunctionBuilder.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder fBlock = new BasicBlock.Builder();
+        BasicBlock.Builder fBlock = fFunctionBuilder.addBlock();
         fBlock.addValue(FunctionCreate.create("g", ImmutableList.of(ComplexConstant.create(new Complex(2, 0)))));
         fBlock.addValue(Return.create(VoidConstant.INSTANCE));
-        fFunctionBuilder.addBlock(fBlock.build());
         programBuilder.addFunction("f", fFunctionBuilder.build());
 
         // test the validator

--- a/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/InstructionValidationFunctionTests.java
+++ b/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/InstructionValidationFunctionTests.java
@@ -91,21 +91,19 @@ class InstructionValidationFunctionTests {
         otherFunction.setReturnType(functionType.getReturnType());
         functionType.getArgumentTypes().stream().map(ArgumentDeclaration::create)
                 .forEachOrdered(otherFunction::addArgument);
-        BasicBlock.Builder otherBlock = new BasicBlock.Builder();
+        BasicBlock.Builder otherBlock = otherFunction.addBlock();
         otherBlock.addValue(
                 Return.create(createConstant(programBuilder, otherBlock, functionType.getReturnType())));
-        otherFunction.addBlock(otherBlock.build());
         programBuilder.addFunction("g", otherFunction.build());
 
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         block.addValue(FunctionCall
                 .create(FunctionCreate.create("g"),
                         functionAndArgs.getRight().stream().map(v -> createConstant(programBuilder, block, v))
                                 .collect(Collectors.toList())));
         block.addValue(Return.create(VoidConstant.INSTANCE));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
@@ -119,10 +117,9 @@ class InstructionValidationFunctionTests {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         block.addValue(FunctionCall.create(NullFunction.INSTANCE));
         block.addValue(Return.create(VoidConstant.INSTANCE));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
@@ -140,21 +137,19 @@ class InstructionValidationFunctionTests {
         otherFunction.setReturnType(functionType.getReturnType());
         functionType.getArgumentTypes().stream().map(ArgumentDeclaration::create)
                 .forEachOrdered(otherFunction::addArgument);
-        BasicBlock.Builder otherBlock = new BasicBlock.Builder();
+        BasicBlock.Builder otherBlock = otherFunction.addBlock();
         otherBlock.addValue(
                 Return.create(createConstant(programBuilder, otherBlock, functionType.getReturnType())));
-        otherFunction.addBlock(otherBlock.build());
         programBuilder.addFunction("g", otherFunction.build());
 
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         block.addValue(FunctionCall
                 .create(FunctionCreate.create("g"),
                         functionAndArgs.getRight().stream().map(v -> createConstant(programBuilder, block, v))
                                 .collect(Collectors.toList())));
         block.addValue(Return.create(VoidConstant.INSTANCE));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
@@ -169,18 +164,16 @@ class InstructionValidationFunctionTests {
 
         FunctionDefinition.Builder otherFunction = new FunctionDefinition.Builder();
         otherFunction.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder otherBlock = new BasicBlock.Builder();
+        BasicBlock.Builder otherBlock = otherFunction.addBlock();
         otherBlock.addValue(Return.create(VoidConstant.INSTANCE));
-        otherFunction.addBlock(otherBlock.build());
         programBuilder.addFunction("g", otherFunction.build());
 
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         block.addValue(FunctionCall
                 .create(FunctionCreate.create("g")));
         block.addValue(Return.create(VoidConstant.INSTANCE));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();

--- a/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/InstructionValidationPointerTests.java
+++ b/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/InstructionValidationPointerTests.java
@@ -86,10 +86,9 @@ public class InstructionValidationPointerTests {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         block.addValue(PointerAllocate.create(valueType));
         block.addValue(Return.create(VoidConstant.INSTANCE));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
@@ -104,10 +103,9 @@ public class InstructionValidationPointerTests {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         block.addValue(PointerAllocate.create(valueType));
         block.addValue(Return.create(VoidConstant.INSTANCE));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
@@ -121,10 +119,9 @@ public class InstructionValidationPointerTests {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         block.addValue(PointerFree.create(createConstant(programBuilder, block, valueType)));
         block.addValue(Return.create(VoidConstant.INSTANCE));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
@@ -138,10 +135,9 @@ public class InstructionValidationPointerTests {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         block.addValue(PointerFree.create(NullPointer.INSTANCE));
         block.addValue(Return.create(VoidConstant.INSTANCE));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
@@ -156,10 +152,9 @@ public class InstructionValidationPointerTests {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         block.addValue(PointerFree.create(createConstant(programBuilder, block, valueType)));
         block.addValue(Return.create(VoidConstant.INSTANCE));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
@@ -190,12 +185,11 @@ public class InstructionValidationPointerTests {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         block.addValue(PointerSet
                 .create(createConstant(programBuilder, block, valueTypes.get(0)),
                         createConstant(programBuilder, block, valueTypes.get(1))));
         block.addValue(Return.create(VoidConstant.INSTANCE));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
@@ -210,13 +204,12 @@ public class InstructionValidationPointerTests {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         var p = block.addValue(PointerAllocate.create(valueTypes.getLeft()));
         block.addValue(PointerSet
                 .create(p, createConstant(programBuilder, block, valueTypes.getRight())));
         block.addValue(PointerFree.create(p));
         block.addValue(Return.create(VoidConstant.INSTANCE));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
@@ -231,11 +224,10 @@ public class InstructionValidationPointerTests {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         block.addValue(
                 PointerSet.create(NullPointer.INSTANCE, createConstant(programBuilder, block, valueType)));
         block.addValue(Return.create(VoidConstant.INSTANCE));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
@@ -250,12 +242,11 @@ public class InstructionValidationPointerTests {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         var p = block.addValue(PointerAllocate.create(valueTypes.getLeft()));
         block.addValue(PointerSet
                 .create(p, createConstant(programBuilder, block, valueTypes.getRight())));
         block.addValue(Return.create(VoidConstant.INSTANCE));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();

--- a/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/InstructionValidationReturnTests.java
+++ b/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/InstructionValidationReturnTests.java
@@ -20,9 +20,8 @@ class InstructionValidationReturnTests {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(valueTypes.getLeft());
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         block.addValue(Return.create(createConstant(programBuilder, block, valueTypes.getRight())));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
@@ -37,9 +36,8 @@ class InstructionValidationReturnTests {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(valueType);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         block.addValue(Return.create(createConstant(programBuilder, block, valueType)));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
@@ -52,9 +50,8 @@ class InstructionValidationReturnTests {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         block.addValue(Return.create(VoidConstant.INSTANCE));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();

--- a/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/ValueTypeAsserts.java
+++ b/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/ValueTypeAsserts.java
@@ -16,11 +16,10 @@ class ValueTypeAsserts {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         block.addValue(creator.create(createConstant(programBuilder, block, argumentTypes.get(0)),
                 createConstant(programBuilder, block, argumentTypes.get(1))));
         block.addValue(Return.create(VoidConstant.INSTANCE));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
@@ -33,11 +32,10 @@ class ValueTypeAsserts {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         block.addValue(creator.create(createConstant(programBuilder, block, argumentTypes.get(0)),
                 createConstant(programBuilder, block, argumentTypes.get(1))));
         block.addValue(Return.create(VoidConstant.INSTANCE));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
@@ -49,10 +47,9 @@ class ValueTypeAsserts {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         block.addValue(creator.create(createConstant(programBuilder, block, argumentType)));
         block.addValue(Return.create(VoidConstant.INSTANCE));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();
@@ -65,10 +62,9 @@ class ValueTypeAsserts {
         Program.Builder programBuilder = new Program.Builder();
         FunctionDefinition.Builder function = new FunctionDefinition.Builder();
         function.setReturnType(ValueTypes.VOID);
-        BasicBlock.Builder block = new BasicBlock.Builder();
+        BasicBlock.Builder block = function.addBlock();
         block.addValue(creator.create(createConstant(programBuilder, block, argumentType)));
         block.addValue(Return.create(VoidConstant.INSTANCE));
-        function.addBlock(block.build());
         programBuilder.addFunction("f", function.build());
 
         Program program = programBuilder.build();

--- a/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/ValueTypeUtils.java
+++ b/generatorvalidation/src/test/java/com/kneelawk/kfractal/generator/validation/ValueTypeUtils.java
@@ -58,12 +58,11 @@ public class ValueTypeUtils {
                     newFunction.addArgument(ArgumentDeclaration.create(argumentType));
                 }
 
-                BasicBlock.Builder newBlock = new BasicBlock.Builder();
+                BasicBlock.Builder newBlock = newFunction.addBlock();
                 newBlock.addValue(Return.create(createConstant(programBuilder, newBlock,
                         ImmutableSet.<String>builder().addAll(usedFunctionNames).add(functionName).build(),
                         usedGlobalNames, functionType.getReturnType())));
 
-                newFunction.addBlock(newBlock.build());
                 programBuilder.addFunction(functionName, newFunction.build());
                 return FunctionCreate.create(functionName);
             }


### PR DESCRIPTION
This pull request addresses the misuse of the BasicBlock.Builder constructor within the tests for the ProgramValidator. Previously, the tests had been constructing BasicBlock.Builders using their constructors, but this is discouraged unless directly intended because it does not initialize references to the basic block with the correct block index.

This pull request also modifies the BasicBlock.Builder constructors so as to force any user to explicitly specify the block's index if constructing the BasicBlock.Builder directly.

This pull request should be good enough to close #69.